### PR TITLE
Fix compatibility with Indico v3.3.3

### DIFF
--- a/indico_mlz_export/api.py
+++ b/indico_mlz_export/api.py
@@ -116,7 +116,7 @@ def all_registrations_csv(event):
         reg_data = _registration.data_by_field
         rdata = {}
         for section in _registration.sections_with_answered_fields:
-            for field in section.active_fields:
+            for field in section.available_fields:
                 if field.id not in reg_data:
                     continue
                 ft = ft_to_logickey(field.title)
@@ -196,7 +196,7 @@ def all_fields(registration, flat=False):
     else:
         data = defaultdict(dict)
     for section in registration.sections_with_answered_fields:
-        for field in section.active_fields:
+        for field in section.available_fields:
             if field.id not in reg_data:
                 continue
             if flat:

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@
        setuptools>=39
        setuptools_scm[toml]>=3.4
     install_requires=
-      indico>=3.1
+      indico>=3.3.3
 [options.entry_points]
         indico.plugins = 
                mlz_export = indico_mlz_export.plugin:MLZExporterPlugin


### PR DESCRIPTION
closes #14 (or at least I think so, I haven't tested it ;))

I recommend releasing this as `v3.3` to match the typical Indico plugin versioning scheme of plugin versions matching the `x.y` part of the (lowest) Indico version they should be used with.